### PR TITLE
Update the target mount point for anti-rewind file

### DIFF
--- a/deployments/ibm/LinuxONE/notary/contract_generator/compose.grep11/docker-compose.yml
+++ b/deployments/ibm/LinuxONE/notary/contract_generator/compose.grep11/docker-compose.yml
@@ -29,7 +29,8 @@ services:
 
     volumes:
       # This is a must as it is needed for anti-rewind file
-      - "/mnt/data:/data"
+      # !!! Changing the target mount point will result in anti-rewind file getting lost on reboot !!!
+      - "/mnt/data:/data/anti-rewind"
 
       # This is only for communicating with grep11 server
       - ".cert:/opt/approval-notary/cert:ro"

--- a/deployments/ibm/LinuxONE/notary/contract_generator/compose.hpcs/docker-compose.yml
+++ b/deployments/ibm/LinuxONE/notary/contract_generator/compose.hpcs/docker-compose.yml
@@ -23,4 +23,5 @@ services:
 
     volumes:
       # This is a must as it is needed for anti-rewind file
-      - "/mnt/data:/data"
+      # !!! Changing the target mount point will result in anti-rewind file getting lost on reboot !!!
+      - "/mnt/data:/data/anti-rewind"


### PR DESCRIPTION
If the target volume is set to "/data", then it results in anti-replay file getting lost on reboot. This happens because, docker mounts /data/anti-rewind after mounting /data and hence it shadows the original /data/