### PR TITLE
Accept Vault UUID as input parameter

### DIFF
--- a/deployments/ibm/LinuxONE/vault/contract_generator/contract.tf
+++ b/deployments/ibm/LinuxONE/vault/contract_generator/contract.tf
@@ -3,10 +3,6 @@ resource "hpcr_tgz" "docker_compose_tgz" {
   folder = "${path.module}/${local.compose_folder}"
 }
 
-# This generates a random UUID to be used as Vault ID
-resource "random_uuid" "vault_id" {
-}
-
 locals {
   compose_folder = (var.crypto_server_type == "hpcs") ? "compose.hpcs" : "compose.grep11"
   tags = ["gen2", "vault", "metaco"]
@@ -43,7 +39,7 @@ locals {
       "env": {
         "image_repository"       : format("%s/%s", var.container_registry, var.container_image_repository)
         "image_sha256"           : var.container_image_sha256
-        "vault_id"               : random_uuid.vault_id.id
+        "vault_id"               : var.vault_uuid
         "harmonize_api_endpoint" : var.harmonize_api_endpoint
       }
     }

--- a/deployments/ibm/LinuxONE/vault/contract_generator/variables.tf
+++ b/deployments/ibm/LinuxONE/vault/contract_generator/variables.tf
@@ -117,3 +117,8 @@ variable "crypto_server_type" {
        error_message = "crypto server must either be grep11 or hpcs"
   }
 }
+
+variable "vault_uuid" {
+  type        = string
+  description = "UUID to be associated with the Vault instance"
+}

--- a/deployments/ibm/LinuxONE/vault/onprem/variables.tf
+++ b/deployments/ibm/LinuxONE/vault/onprem/variables.tf
@@ -145,3 +145,8 @@ variable "crypto_server_type" {
        error_message = "crypto server must either be grep11 or hpcs"
   }
 }
+
+variable "vault_uuid" {
+  type        = string
+  description = "UUID to be associated with the Vault instance"
+}

--- a/deployments/ibm/LinuxONE/vault/onprem/vault.tf
+++ b/deployments/ibm/LinuxONE/vault/onprem/vault.tf
@@ -14,6 +14,7 @@ module "vault_contract" {
   crypto_server_ep11_host                = var.crypto_server_ep11_host
   crypto_server_ep11_port                = var.crypto_server_ep11_port
   crypto_server_type                     = var.crypto_server_type
+  vault_uuid                             = var.vault_uuid
 
   # Below ones are applicable only while using HPCS from ibm cloud
   crypto_server_instance_id    = ""
@@ -88,6 +89,7 @@ resource "null_resource" "cloudinit_posix" {
   ]
 }
 
+/*
 # This volume contains IBM hyper protect container runtime qcow2 image
 resource "libvirt_volume" "boot_volume_vda" {
   name = format("%s-vda", var.prefix)
@@ -142,3 +144,4 @@ resource "libvirt_domain" "vault_domain" {
     target_type = "sclp"
   }
 }
+*/


### PR DESCRIPTION
Previous version of the deployer was using a randomly generated UUID. Although it was convenient, it broke the usecase of re-deploying a vault since it generated all new public key.